### PR TITLE
Add some missing sector-categories to CSV

### DIFF
--- a/dstore/csv/sector_category.csv
+++ b/dstore/csv/sector_category.csv
@@ -13,6 +13,12 @@ code,name
 210,Transport and storage
 220,Communication
 230,Energy generation and supply
+231,"Energy generation, distribution and efficiency – general"
+232,"Energy generation, renewable sources"
+233,"Energy generation, non-renewable sources"
+234,Hybrid energy electric power plants
+235,Nuclear energy electric power plants
+236,"Heating, cooling and energy distribution"
 240,Banking and financial services
 250,Business and other services
 311,Agriculture


### PR DESCRIPTION
This adds a handful of sector categories that are present in the source json but not the local CSV:
http://iatistandard.org/202/codelists/downloads/clv3/json/en/SectorCategory.json

Out of interest: Why don’t you use the source json for this, like for other codelists? Looks like you used to: 37037cb2

[Also… Biiiit worried I have borked the line endings here… Hopefully it’s okay :\ ]