### PR TITLE
Add "%" suffix to `measure="2"` baseline values

### DIFF
--- a/ctrack/art/high/activities.css
+++ b/ctrack/art/high/activities.css
@@ -200,7 +200,7 @@ result indicator:before		{counter-increment:subsection; content:counter(section)
 result indicator[measure="1"]:before,
 result indicator[measure="2"]:before	{content:counter(section) "." counter(subsection) " INDICATOR";}
 
-result indicator[measure="2"] period target span-narrative:after, result indicator[measure="2"] period actual span-narrative:after	{content:" %";}
+result indicator[measure="2"] period baseline span-narrative:after, result indicator[measure="2"] period target span-narrative:after, result indicator[measure="2"] period actual span-narrative:after	{content:" %";}
 
 result indicator span-title	{display:inline-block; width:100%; vertical-align:top; font-size:16px; line-height:22px; padding:0 30px 0 0; box-sizing:border-box;}
 result indicator span-title:before {content:" "; margin:0; border:0;}


### PR DESCRIPTION
The percentage is missing from baseline values:
![screen shot 2018-03-13 at 17 30 59](https://user-images.githubusercontent.com/464193/37358986-5a23f448-26e4-11e8-8ba9-741a6c2928fe.png)

This PR makes it look like this:
![screen shot 2018-03-13 at 17 32 48](https://user-images.githubusercontent.com/464193/37359093-97bf66c0-26e4-11e8-8d35-d150d6401057.png)

I guess you could add a % to the title, too, but I haven’t done that here.