### PR TITLE
Show valid recipient countries first

### DIFF
--- a/ctrack/js/view_dash.js
+++ b/ctrack/js/view_dash.js
@@ -150,12 +150,12 @@ view_dash.ajax3=function(args)
 	{
 //		console.log("view_dash.ajax");
 //		console.log(data);
-		
-// push bad data to the top
+
+// push bad data to the bottom
 		data.rows.sort(function(a,b){
 			var av=(iati_codes.country[a.country_code]) && 1 || 0;
 			var bv=(iati_codes.country[b.country_code]) && 1 || 0;
-			if(av!=bv) { return av-bv; }
+			if(av!=bv) { return bv-av; }
 			if(a.count!=b.count) { return b.count-a.count; }
 			if(a.country_code<b.country_code){ return -1; }
 			if(a.country_code>b.country_code){ return  1; }


### PR DESCRIPTION
[Dash](http://d-portal.org/ctrack.html#view=dash) shows invalid recipient countries before valid ones:
![screen shot 2018-04-05 at 09 46 00](https://user-images.githubusercontent.com/464193/38355925-315e7aa4-38b6-11e8-8a51-086ac2f36ca4.png)

I wonder if this should be the other way around?

It looks like it has been done like this very deliberately, so there might be a good reason to do it this way! (Possibly because Dash is for finding data errors (?), so erroneous recipient countries are more relevant.)

Anyway, I thought I’d send the PR all the same!